### PR TITLE
Change from MQTT to EVCC REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Dieses Arduino-Projekt für den ESP8266-Mikrocontroller visualisiert Energiedate
    - WLAN-Zugangsdaten (`ssid` und `password`)
    - RestAPI-Adresse (`api_endpoint`)
    - LED-Pin und Anzahl der LEDs (`LED_PIN` und `NUM_LEDS`)
+   - Die Leistung in Watt welche eine LED darstellt (`WATTS_PER_LED`)
 
 6. Wählen Sie das korrekte ESP8266-Board und den COM-Port in der Arduino IDE aus.
   - Für ESP01s: "Generic ESP8266 Module"

--- a/README.md
+++ b/README.md
@@ -2,24 +2,33 @@
 
 ## Beschreibung
 
-PowerRing ist ein Arduino-Projekt für den ESP8266, das einen RGB LED-Ring zur Visualisierung von Photovoltaik-Daten verwendet. Es empfängt MQTT-Nachrichten von einem [EVCC](https://github.com/evcc-io/evcc)-System und stellt die PV-Leistung, den Hausverbrauch, den Netzbezug und den Ladestatus eines Elektrofahrzeugs dar.
+Dieses Arduino-Projekt für den ESP8266-Mikrocontroller visualisiert Energiedaten einer Photovoltaikanlage auf einem 24 Bit NeoPixel LED-Ring. Es nutzt die von [EVCC](https://github.com/evcc-io/evcc) über die REST-API zur Verfügung gestellten Daten und stellt die PV-Leistung, den Hausverbrauch, den Netzbezug und den Ladestatus des Elektrofahrzeugs dar.
 ![grafik](https://github.com/user-attachments/assets/8217c266-0f09-45db-93c6-3c3f7e4cac4d)
 ![PXL_20250202_104355275](https://github.com/user-attachments/assets/f247cdca-fc6e-4127-9a42-6a3cc9124ebd)
 
 
 ## Funktionen
 
-- Visualisierung von PV-Leistung, Hausverbrauch und Netzbezug auf einem LED-Ring
-- Anzeige des EV-Ladestatus
-- MQTT-Integration für Datenaktualisierung
+- Abruf von Energiedaten via EVCC REST-API
+- Visualisierung auf 24-LED NeoPixel Ring
+- Darstellung von PV-Produktion, Netzbezug/-einspeisung und Ladestatus anhand der Farbe und Anzahl der LEDs
 - Sanftes Dimmen der LEDs bei Zustandsänderungen
-- Fehleranzeige bei Verbindungsproblemen
+- Fehleranzeige bei Verbindungsproblemen / Debug Infos über Serielle Schnittstelle
+
+## Farbcodes auf dem LED Ring (analog zu EVCC)
+
+- 🟢 Grün: Hausverbrauch der von der PV-Produktion gedeckt ist.
+- 🟡 Gelb: in Netz eingespeiste überschüssige PV-Energie 
+- 🔴 Rot: Netzbezug (in der EVCC GUI als grau ⚪ dargestellt)
+- 🔵 Blau (Nur erste LED): Fahrzeug lädt
 
 ## Hardware-Anforderungen
 
-- ESP8266 Mikrocontroller (Hier ESP01 aber z.B. NodeMCU, Wemos D1 Mini)
+- ESP8266 Mikrocontroller (Hier ESP01 aber auch z.B. NodeMCU, Wemos D1 Mini)
 - WS2812B RGB LED-Ring (Anzahl der LEDs konfigurierbar)
-- Stromversorgung für ESP8266 und LED-Ring
+- Stromversorgung für ESP8266 und LED-Ring:
+  - z.B. AMS1117 DC-DC Step Down Buck Converter mit
+  - Adafruit 1833 USB MICRO-B BREAKOUT BOARD
 
 ## Software-Anforderungen
 
@@ -27,73 +36,71 @@ PowerRing ist ein Arduino-Projekt für den ESP8266, das einen RGB LED-Ring zur V
 - ESP8266 Board-Unterstützung für Arduino IDE
 - Folgende Bibliotheken:
   - ESP8266WiFi
-  - PubSubClient
-  - Adafruit_NeoPixel (Version 1.8.4)
+  - ESP8266HTTPClient
+  - ArduinoJson
+  - Adafruit_NeoPixel (Achtung: Version 1.8.4)
 
 ## Installation
 
-1. Klonen Sie dieses Repository oder laden Sie den Quellcode herunter.
+1. Laden Sie PowerRing.ino Datei runter.
 
 2. Öffnen Sie die Arduino IDE und installieren Sie die ESP8266 Board-Unterstützung:
    - Fügen Sie `http://arduino.esp8266.com/stable/package_esp8266com_index.json` zu den zusätzlichen Boardverwalter-URLs in den Arduino-Einstellungen hinzu.
    - Installieren Sie das ESP8266-Paket über den Boardverwalter.
 
 3. Installieren Sie die erforderlichen Bibliotheken über den Bibliotheksverwalter der Arduino IDE:
-   - PubSubClient
+   - ESP8266WiFi
+   - ESP8266HTTPClient
+   - ArduinoJson
    - Adafruit_NeoPixel (Version 1.8.4)
 
-Wichtiger Hinweis: Stellen Sie sicher, dass Sie die Adafruit_NeoPixel Bibliothek in der Version 1.8.4 installieren. Neuere Versionen sind nicht kompatibel mit dem ESP01. Um eine spezifische Version zu installieren:
+      Achtung: Stellen Sie sicher, dass Sie die Adafruit_NeoPixel Bibliothek in der Version 1.8.4 installieren. Neuere Versionen sind nicht kompatibel mit dem ESP01. Um eine spezifische Version zu installieren:
 
-1. Öffnen Sie den Bibliotheksverwalter in der Arduino IDE (Sketch > Bibliothek einbinden > Bibliotheken verwalten...)
-2. Suchen Sie nach "Adafruit NeoPixel"
-3. Klicken Sie auf den Dropdown-Pfeil neben der Versionsnummer
-4. Wählen Sie Version 1.8.4 aus und klicken Sie auf "Installieren"
+      1. Öffnen Sie den Bibliotheksverwalter in der Arduino IDE (Sketch > Bibliothek einbinden > Bibliotheken verwalten...)
+      2. Suchen Sie nach "Adafruit NeoPixel"
+      3. Klicken Sie auf den Dropdown-Pfeil neben der Versionsnummer
+      4. Wählen Sie Version 1.8.4 aus und klicken Sie auf "Installieren"
 
 4. Öffnen Sie die `PowerRing.ino` Datei in der Arduino IDE.
 
 5. Konfigurieren Sie die folgenden Variablen in der Datei:
    - WLAN-Zugangsdaten (`ssid` und `password`)
-   - MQTT-Broker-Adresse (`mqtt_server`)
+   - RestAPI-Adresse (`api_endpoint`)
    - LED-Pin und Anzahl der LEDs (`LED_PIN` und `NUM_LEDS`)
-   - MQTT-Topics für die verschiedenen Messwerte
 
 6. Wählen Sie das korrekte ESP8266-Board und den COM-Port in der Arduino IDE aus.
+  - Für ESP01s: "Generic ESP8266 Module"
+  - Flash Size: "1M (no SPIFFS)" 
 
-7. Kompilieren und hochladen Sie den Code auf Ihren ESP8266.
+8. Sketch kompilieren und über seriellen Adapter aus den ESP8266 flashen.
+
+## EVCC REST-API
+Details zur verwendeten API: [EVCC REST-API Dokumentation](https://docs.evcc.io/docs/integrations/rest-api)
 
 ## Verkabelung
 
-- Verbinden Sie den Daten-Pin des LED-Rings mit dem in `LED_PIN` definierten Pin des ESP8266 (Standard: D3). --> Siehe Schematic weiter unten
+- Verbinden Sie den Daten-Pin (DIN) des LED-Rings mit dem in `LED_PIN` definierten Pin des ESP8266 (z.B. GPIO0 a.k.a. D3 = 0). --> Siehe Schematic weiter unten
 - Stellen Sie sicher, dass der LED-Ring und der ESP8266 eine gemeinsame Masse haben.
-- Versorgen Sie den LED-Ring und den ESP8266 mit ausreichend Strom.
-
-## Verwendung
-
-Nach dem Hochladen des Codes und der korrekten Verkabelung wird der ESP8266 versuchen, sich mit dem konfigurierten WLAN und MQTT-Broker zu verbinden. Die LEDs zeigen dann die empfangenen EVCC PV-Daten wie folgt an:
-
-- Grün: Hausverbrauch aus PV-Leistung
-- Gelb: Überschüssige PV-Leistung
-- Rot: Netzbezug
-- Blau (erste LED): EV lädt
+- Versorgen Sie den LED-Ring und den ESP8266 mit ausreichend Strom. (z.B. passendes USB-Ladegerät)
 
 Bei Verbindungsproblemen blinkt die erste LED orange.
 
 ## Fehlerbehebung
 
 - Überprüfen Sie die serielle Konsole für Debug-Informationen.
-- Stellen Sie sicher, dass die WLAN- und MQTT-Broker-Einstellungen korrekt sind.
+- Orange blinkende LED: API-Verbindungsproblem
 - Überprüfen Sie die Verkabelung des LED-Rings.
 
 ***
 
-## Referenz Hardware:
+## Meine Referenz Hardware:
 
 - 24Bit RGB LED Ring WS2812
-- ESP-01S (or any other board running ESP Easy FW)
+- ESP-01S
 - AMS1117 DC-DC Step Down Buck Converter 3.3 V BREAKOUT Board
-- EVCC running on e.g. RaspberryPi with MQTT configured
-- (optional) Adafruit 1833 USB MICRO-B BREAKOUT BOARD
-- (optional) IKEA "Bergenes Halter für Mobiltelefon/Tablet" mit zwei Plexiglasscheiben
+- EVCC running on e.g. RaspberryPi or Synology Docker
+- Adafruit 1833 USB MICRO-B BREAKOUT BOARD
+- IKEA "Bergenes Halter für Mobiltelefon/Tablet" mit zwei Plexiglasscheiben
 
 ### Schematic:
 


### PR DESCRIPTION
Wechsel von MQTT zu REST API für Datenabruf
- Nutzt direkt die EVCC REST API für Datenzugriff
- Eliminiert Abhängigkeit von MQTT Broker
- Erhöht somit die Kompatibilität mit verschiedenen Setups
